### PR TITLE
check whether LEMONPATTERNS_HOME is set

### DIFF
--- a/lemonpatterns
+++ b/lemonpatterns
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-LEMONPATTERNS_HOME=.
+if [[ -z "$LEMONPATTERNS_HOME" ]]
+then
+    LEMONPATTERNS_HOME=.
+fi
 
 die () {
     echo >&2 "$@"


### PR DESCRIPTION
The bash script now first checks whether LEMONPATTERNS_HOME is already set (and only if not, sets it to current directory).
